### PR TITLE
service-worker: error on "fetch" event

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -69,6 +69,9 @@ self.addEventListener('notificationclick', function(event) {
 
 // This is needed for 'Add to Home Screen'.
 self.addEventListener('fetch', function(event) {
+    if (event.request.cache === 'only-if-cached' && event.request.mode !== 'same-origin') {
+        return;
+    }
 	event.respondWith(
     //  Try to find response in cache.
     caches.match(event.request)


### PR DESCRIPTION
Chrome 70.0.3538.110
Sometimes i get this error: `Uncaught (in promise) TypeError: Failed to execute 'fetch' on 'ServiceWorkerGlobalScope': 'only-if-cached' can be set only with 'same-origin' mode