### PR TITLE
add Inlang to make the contribution of translations easier

### DIFF
--- a/inlang.config.js
+++ b/inlang.config.js
@@ -7,7 +7,7 @@ export async function defineConfig(env) {
   );
 
   const pluginConfig = {
-    pathPattern: "./{language}.json",
+    pathPattern: "./src/i18n/{language}.json",
   };
 
   return {

--- a/inlang.config.js
+++ b/inlang.config.js
@@ -1,0 +1,31 @@
+// https://inlang.com/documentation
+
+
+export async function defineConfig(env) {
+  const plugin = await env.$import(
+    "https://cdn.jsdelivr.net/gh/samuelstroschein/inlang-plugin-json@1/dist/index.js"
+  );
+
+  const pluginConfig = {
+    pathPattern: "./{language}.json",
+  };
+
+  return {
+    referenceLanguage: "en",
+    languages: [
+      "de", 
+      "en",
+      "es",
+      "fr",
+      "ko",
+      "ro",
+      "ru",
+      "zh-TW",
+      "zh"
+    ],
+    readResources: (args) =>
+      plugin.readResources({ ...args, ...env, pluginConfig }),
+    writeResources: (args) =>
+      plugin.writeResources({ ...args, ...env, pluginConfig }),
+  };
+}


### PR DESCRIPTION
Hi there, 

I created an inlang.config.js file that enables contributors to contribute translations via a UI that opens pull requests. See https://inlang.com/editor/github.com/samuelstroschein/webapp. 

The service worker translations are not included yet. I also did not update the [readme](https://github.com/tinode/chat/blob/devel/docs/translations.md#webapp) on how to contribute translations yet. If desired, I can update the README too. Theoretically, the Android and iOS apps could also be used with inlang. 

Let me know what you need to merge this PR. 

PS yes, cloning takes ages. We are working on this as part of [the next git](https://inlang.com/documentation/the-next-git).